### PR TITLE
Fix process mapping for Korean machine types

### DIFF
--- a/aas_pathfinder.py
+++ b/aas_pathfinder.py
@@ -58,6 +58,9 @@ TYPE_PROCESS_MAP = {
     "Cylindrical grinder": "Grinding",
     "Assembly System": "Assembly",
     "그라인더": "Grinding",
+    "단조": "Forging",
+    "밀링": "Milling",
+    "선반": "Turning",
 }
 
 @dataclass


### PR DESCRIPTION
## Summary
- support Korean machine type names when mapping to manufacturing processes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'basyx' and 'pymongo')*

------
https://chatgpt.com/codex/tasks/task_e_6883360699f88323a1817e3b33d15d7d