### PR TITLE
Fix ModelReference compatibility

### DIFF
--- a/aas_batch_generator.py
+++ b/aas_batch_generator.py
@@ -23,6 +23,17 @@ def sanitize_id_short(s: str) -> str:
         s = "X_" + s
     return s
 
+def ref_from_keys(keys):
+    """Return a ``ModelReference`` built from ``keys``.
+
+    Some versions of ``basyx`` expose ``ModelReference.from_keys`` while others
+    expect the keys in the constructor.  This helper provides a consistent
+    interface across versions.
+    """
+    if hasattr(ModelReference, "from_keys"):
+        return ModelReference.from_keys(keys)
+    return ModelReference(keys=keys)
+
 def mlp(id_short: str, text: str, lang: str = 'en') -> MultiLanguageProperty:
     return MultiLanguageProperty(id_short=id_short, value=LangStringSet({lang: str(text)}))
 
@@ -142,14 +153,14 @@ def make_event_submodel(uid) -> Submodel:
     sm = Submodel(id_=f"https://example.com/submodel/StatusEvent_{uid}")
     event = model.BasicEventElement(
         id_short="StatusChangeEvent",
-        observed=ModelReference.from_keys([
+        observed=ref_from_keys([
             model.Key(type_=model.KeyTypes.SUBMODEL, value=f"https://example.com/submodel/Operation_{uid}"),
             model.Key(type_=model.KeyTypes.PROPERTY, value="MachineStatus"),
         ]),
         direction="output",
         state="on",
         message_topic=f"aas/status/{uid}",
-        message_broker=ModelReference.from_keys([
+        message_broker=ref_from_keys([
             model.Key(type_=model.KeyTypes.SUBMODEL, value=f"https://example.com/submodel/MQTTBrokerConfig_{uid}")
         ]),
         min_interval="PT1S",

--- a/aas_create_test.py
+++ b/aas_create_test.py
@@ -24,6 +24,12 @@ def mlp(id_short: str, text: str, lang: str = 'en') -> MultiLanguageProperty:
         value=LangStringSet({lang: text})
     )
 
+def ref_from_keys(keys):
+    """Helper creating ``ModelReference`` from ``keys`` for all SDK versions."""
+    if hasattr(ModelReference, "from_keys"):
+        return ModelReference.from_keys(keys)
+    return ModelReference(keys=keys)
+
 # Submodel 생성 함수들
 
 def create_nameplate_submodel() -> Submodel:
@@ -169,13 +175,13 @@ def create_basicevent_submodel() -> Submodel:
 
     event = model.BasicEventElement(
         id_short="StatusChangeEvent",
-        observed=model.ModelReference.from_keys([
+        observed=ref_from_keys([
             model.Key(type_=model.KeyTypes.SUBMODELELEMENT, value="MachineStatus")
         ]),
         direction="output",
         state="on",
         message_topic="aas/status/Machine001",
-        message_broker=model.ModelReference.from_keys([
+        message_broker=ref_from_keys([
             model.Key(type_=model.KeyTypes.SUBMODEL, value="MQTTBrokerConfig")
         ]),
         min_interval="PT1S",


### PR DESCRIPTION
## Summary
- add `ref_from_keys` helper to handle SDK differences
- use the helper when building event-related references

## Testing
- `pytest -q` *(fails: No module named 'basyx'; No module named 'pymongo')*

------
https://chatgpt.com/codex/tasks/task_e_68834025e6e483238dca2e5c6eca834c