### PR TITLE
Fix ModelReference constructor fallback

### DIFF
--- a/aas_batch_generator.py
+++ b/aas_batch_generator.py
@@ -32,7 +32,12 @@ def ref_from_keys(keys):
     """
     if hasattr(ModelReference, "from_keys"):
         return ModelReference.from_keys(keys)
-    return ModelReference(keys=keys)
+    try:
+        # Older SDK versions expect ``keys`` as keyword argument
+        return ModelReference(keys=keys)
+    except TypeError:
+        # Newer versions take the keys sequence as positional argument
+        return ModelReference(keys)
 
 def mlp(id_short: str, text: str, lang: str = 'en') -> MultiLanguageProperty:
     return MultiLanguageProperty(id_short=id_short, value=LangStringSet({lang: str(text)}))

--- a/aas_create_test.py
+++ b/aas_create_test.py
@@ -28,7 +28,10 @@ def ref_from_keys(keys):
     """Helper creating ``ModelReference`` from ``keys`` for all SDK versions."""
     if hasattr(ModelReference, "from_keys"):
         return ModelReference.from_keys(keys)
-    return ModelReference(keys=keys)
+    try:
+        return ModelReference(keys=keys)
+    except TypeError:
+        return ModelReference(keys)
 
 # Submodel 생성 함수들
 


### PR DESCRIPTION
## Summary
- fix compatibility for ModelReference helper functions

## Testing
- `pytest -q` *(fails: No module named 'basyx', 'pymongo')*

------
https://chatgpt.com/codex/tasks/task_e_688341707b3c8323903c634d635e4e7a