### PR TITLE
Fix KeyTypes enum usage

### DIFF
--- a/aas_batch_generator.py
+++ b/aas_batch_generator.py
@@ -30,7 +30,7 @@ def _infer_ref_class(key_type: KeyTypes):
     """Map ``KeyTypes`` to the corresponding basyx model class."""
     return {
         KeyTypes.SUBMODEL: model.Submodel,
-        KeyTypes.SUBMODELELEMENT: model.SubmodelElement,
+        KeyTypes.SUBMODEL_ELEMENT: model.SubmodelElement,
         KeyTypes.PROPERTY: model.Property,
     }.get(key_type, model.Referable)
 

--- a/aas_create_test.py
+++ b/aas_create_test.py
@@ -27,7 +27,7 @@ def mlp(id_short: str, text: str, lang: str = 'en') -> MultiLanguageProperty:
 def _infer_ref_class(key_type: model.KeyTypes):
     return {
         model.KeyTypes.SUBMODEL: model.Submodel,
-        model.KeyTypes.SUBMODELELEMENT: model.SubmodelElement,
+        model.KeyTypes.SUBMODEL_ELEMENT: model.SubmodelElement,
         model.KeyTypes.PROPERTY: model.Property,
     }.get(key_type, model.Referable)
 
@@ -188,7 +188,7 @@ def create_basicevent_submodel() -> Submodel:
     event = model.BasicEventElement(
         id_short="StatusChangeEvent",
         observed=ref_from_keys([
-            model.Key(type_=model.KeyTypes.SUBMODELELEMENT, value="MachineStatus")
+            model.Key(type_=model.KeyTypes.SUBMODEL_ELEMENT, value="MachineStatus")
         ]),
         direction="output",
         state="on",


### PR DESCRIPTION
## Summary
- update KeyTypes constant name to match enum

## Testing
- `pytest -q` *(fails: No module named 'basyx'; No module named 'pymongo')*

------
https://chatgpt.com/codex/tasks/task_e_6883518ecb108323bd9782766101a85f