### PR TITLE
Fix model reference helper

### DIFF
--- a/aas_batch_generator.py
+++ b/aas_batch_generator.py
@@ -46,9 +46,8 @@ def ref_from_keys(keys):
     if hasattr(ModelReference, "from_keys"):
         return ModelReference.from_keys(keys)
 
-    key_type = getattr(keys[-1], "type_", getattr(keys[-1], "type", None))
+    key_type = getattr(keys[-1], "type", getattr(keys[-1], "type_", None))
     ref_cls = _infer_ref_class(key_type)
-    ref_cls = _infer_ref_class(keys[-1].type_)
     return ModelReference(tuple(keys), ref_cls)
 
 def mlp(id_short: str, text: str, lang: str = 'en') -> MultiLanguageProperty:


### PR DESCRIPTION
## Summary
- fix `ref_from_keys` to read `Key.type` attribute

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'basyx')*

------
https://chatgpt.com/codex/tasks/task_e_688353827ef08323be596cd3ea4d4166