### PR TITLE
Fix Mongo collection config

### DIFF
--- a/run_simulation.py
+++ b/run_simulation.py
@@ -80,9 +80,9 @@ event_server.MongoClient = _shared_mongo
 event_server.mqtt.Client = FakeMQTTClient
 
 # 기본 설정
-MONGO_URI = 'mongodb://localhost'
-DB_NAME = 'aas'
-COL_NAME = 'instances'
+MONGO_URI = "mongodb://localhost:27017"
+DB_NAME = "test_db"
+COL_NAME = "aas_documents"
 BROKER_URL = 'mqtt://localhost'
 
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
## Summary
- configure `run_simulation.py` with the correct MongoDB URI, DB and collection names

## Testing
- `PYTHONPATH=. pytest tests/test_upload_aas_documents.py -q`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'basyx')*

------
https://chatgpt.com/codex/tasks/task_e_68835fc806f88323a452e8346aec58e4