### PR TITLE
Store simplified AAS under json field and verify load

### DIFF
--- a/aas_pathfinder.py
+++ b/aas_pathfinder.py
@@ -102,8 +102,7 @@ def upload_aas_documents(upload_dir: str, mongo_uri: str, db_name: str, collecti
             continue
 
         simplified = simplify_aas_document(content)
-        document = {"filename": filename}
-        document.update(simplified)
+        document = {"filename": filename, "json": simplified}
 
         try:
             collection.replace_one({"filename": filename}, document, upsert=True)
@@ -270,7 +269,7 @@ def load_machines_from_mongo(
 
         # 2) submodels를 URL 끝부분(소문자)으로 인덱싱
         submodels_index: Dict[str, List[Dict[str, Any]]] = {}
-        for sm in aas.get("submodels", []):
+        for sm in shell.get("submodels", []):
             sm_id = sm.get("id", "")
             key = sm_id.split("/")[-1].lower()
             submodels_index[key] = sm.get("submodelElements", [])

--- a/tests/test_upload_aas_documents.py
+++ b/tests/test_upload_aas_documents.py
@@ -1,15 +1,25 @@
 import json
-import types
-import builtins
-from pathlib import Path
+import os
+import sys
 from unittest import mock
-from aas_pathfinder import upload_aas_documents
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from aas_pathfinder import load_machines_from_mongo, upload_aas_documents
 
 class FakeCollection:
     def __init__(self):
         self.calls = []
+        self.data = {}
+
     def replace_one(self, filter, doc, upsert=False):
         self.calls.append((filter, doc, upsert))
+        key = filter.get("filename")
+        if key:
+            self.data[key] = doc
+
+    def find(self):
+        return list(self.data.values())
 
 class FakeDB(dict):
     def __getitem__(self, name):
@@ -45,8 +55,43 @@ def test_upload_aas_documents(tmp_path):
     assert collection.calls
     filt, doc, upsert = collection.calls[0]
     assert filt == {"filename": "sample.json"}
-    assert "raw" not in doc
-    assert "submodels" not in doc
-    aas_submodels = doc["assetAdministrationShells"][0]["submodels"]
+    assert "json" in doc and doc["json"]["assetAdministrationShells"]
+    assert "raw" not in doc["json"]
+    assert "submodels" not in doc["json"]
+    aas_submodels = doc["json"]["assetAdministrationShells"][0]["submodels"]
     assert aas_submodels[0]["id"] == "sm1"
     assert upsert is True
+
+
+def test_upload_then_load(tmp_path):
+    sample = {
+        "assetAdministrationShells": [
+            {
+                "id": "aas1",
+                "submodels": [
+                    {"type": "ModelReference", "keys": [{"type": "Submodel", "value": "Nameplate_aas1"}]},
+                    {"type": "ModelReference", "keys": [{"type": "Submodel", "value": "Category_aas1"}]},
+                    {"type": "ModelReference", "keys": [{"type": "Submodel", "value": "Operation_aas1"}]},
+                ],
+            }
+        ],
+        "submodels": [
+            {"id": "Nameplate_aas1", "modelType": "Submodel", "submodelElements": []},
+            {"id": "Category_aas1", "modelType": "Submodel", "submodelElements": []},
+            {"id": "Operation_aas1", "modelType": "Submodel", "submodelElements": []},
+        ],
+    }
+    (tmp_path / "sample.json").write_text(json.dumps(sample), encoding="utf-8")
+    fake_client = FakeClient()
+    with mock.patch("aas_pathfinder.MongoClient", return_value=fake_client):
+        upload_aas_documents(str(tmp_path), "mongodb://localhost", "db", "col")
+        with mock.patch("aas_pathfinder.geocode_address", return_value=(0.0, 0.0)):
+            with mock.patch("aas_pathfinder._find_address", return_value="addr"):
+                with mock.patch("aas_pathfinder._find_process", return_value="proc"):
+                    with mock.patch("aas_pathfinder._find_status", return_value="run"):
+                        machines = load_machines_from_mongo("mongodb://localhost", "db", "col")
+
+    assert "aas1" in machines
+    machine = machines["aas1"]
+    stored = fake_client["db"]["col"].data["sample.json"]["json"]
+    assert machine.data == stored


### PR DESCRIPTION
## Summary
- Store simplified AAS documents in MongoDB with a `json` field
- Adjust machine loader to index submodels from the shell entries
- Add tests for upload and subsequent loading to ensure schema consistency

## Testing
- `pytest -q` *(fails: No module named 'basyx')*
- `pytest tests/test_upload_aas_documents.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689acbe68bfc8323b901a4aab120e977